### PR TITLE
Updated getTransactions and added getPendingTransactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,21 +200,23 @@ Example:
 bitx.getOrder('BXHW6PFRRXKFSB4', function(err, result) {});
 ```
 
-### getTransactions(asset, [options, ]callback)
-GET https://api.mybitx.com/api/1/transactions
+### getTransactions(account_id, [options, ]callback)
+GET https://api.mybitx.com/api/1/accounts/:id/transactions
+
+You can find your account_id by calling the Balances API.
 
 Default options:
 ```javascript
 {
-  offset: 0,
-  limit: 10
+  min_row: 0,
+  max_row: 100
 }
 ```
 
 Example:
 
 ```javascript
-bitx.getTransactions('XBT', {offset: 5, limit: 20}, function(err, transactions) {});
+bitx.getTransactions('319232323', {min_row: 5, max_row: 20}, function(err, transactions) {});
 ```
 
 ### getPendingTransactions(account_id, callback)

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ You can find your account_id by calling the Balances API.
 Default options:
 ```javascript
 {
-  min_row: 0,
+  min_row: 1,
   max_row: 100
 }
 ```

--- a/README.md
+++ b/README.md
@@ -217,6 +217,17 @@ Example:
 bitx.getTransactions('XBT', {offset: 5, limit: 20}, function(err, transactions) {});
 ```
 
+### getPendingTransactions(account_id, callback)
+GET https://api.mybitx.com/api/1/accounts/:id/pending
+
+You can find your account_id by calling the Balances API.
+
+Example:
+
+```javascript
+bitx.getPendingTransactions('319232323', function(err, pendingTransactions) {});
+```
+
 ### getWithdrawals(callback)
 GET https://api.mybitx.com/api/1/withdrawals
 

--- a/lib/BitX.js
+++ b/lib/BitX.js
@@ -218,17 +218,16 @@ BitX.prototype.createFundingAddress = function (asset, callback) {
   this._request('POST', 'funding_address', {asset: asset}, callback)
 }
 
-BitX.prototype.getTransactions = function (asset, options, callback) {
+BitX.prototype.getTransactions = function (account_id, options, callback) {
   if (typeof options === 'function') {
     callback = options
     options = null
   }
   var defaults = {
-    asset: asset,
-    offset: 0,
-    limit: 10
+    min_row: 0,
+    max_row: 100
   }
-  this._request('GET', 'transactions', extend(defaults, options), callback)
+  this._request('GET', 'accounts/' + account_id + '/transactions', extend(defaults, options), callback)
 }
 
 BitX.prototype.getPendingTransactions = function (account_id, callback) {

--- a/lib/BitX.js
+++ b/lib/BitX.js
@@ -224,7 +224,7 @@ BitX.prototype.getTransactions = function (account_id, options, callback) {
     options = null
   }
   var defaults = {
-    min_row: 0,
+    min_row: 1,
     max_row: 100
   }
   this._request('GET', 'accounts/' + account_id + '/transactions', extend(defaults, options), callback)

--- a/lib/BitX.js
+++ b/lib/BitX.js
@@ -231,6 +231,10 @@ BitX.prototype.getTransactions = function (asset, options, callback) {
   this._request('GET', 'transactions', extend(defaults, options), callback)
 }
 
+BitX.prototype.getPendingTransactions = function (account_id, callback) {
+  this._request('GET', 'accounts/' + account_id + '/pending', null, callback)
+}
+
 BitX.prototype.getWithdrawals = function (callback) {
   this._request('GET', 'withdrawals/', null, callback)
 }


### PR DESCRIPTION
The new Luno API requires an account_id to retrieve transactions. If you are currently using getTransactions you will need to update your code to use min_row and max_row to specify transaction range. You will also need to pass in your account_id instead of using the asset code.